### PR TITLE
#8 Don't use autowired or constructor injection with FactoryBeans

### DIFF
--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/config/DynamoDBMapperFactory.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/config/DynamoDBMapperFactory.java
@@ -15,32 +15,34 @@
  */
 package org.socialsignin.spring.data.dynamodb.repository.config;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.FactoryBean;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
 
-public class DynamoDBMapperFactory implements FactoryBean<DynamoDBMapper> {
+public class DynamoDBMapperFactory implements FactoryBean<DynamoDBMapper>, BeanFactoryAware {
 
-	private final AmazonDynamoDB amazonDynamoDB;
-	private final DynamoDBMapperConfig dynamoDBMapperConfig;
-
-	@Autowired
-	public DynamoDBMapperFactory(AmazonDynamoDB amazonDynamoDB, DynamoDBMapperConfig dynamoDBMapperConfig) {
-		this.amazonDynamoDB = amazonDynamoDB;
-		this.dynamoDBMapperConfig = dynamoDBMapperConfig;
-	}
-
+	private BeanFactory beanFactory;
+    
 	@Override
 	public DynamoDBMapper getObject() throws Exception {
+		AmazonDynamoDB amazonDynamoDB = beanFactory.getBean(AmazonDynamoDB.class);
+		DynamoDBMapperConfig dynamoDBMapperConfig = beanFactory.getBean(DynamoDBMapperConfig.class);
 		return new DynamoDBMapper(amazonDynamoDB, dynamoDBMapperConfig);
 	}
 
 	@Override
 	public Class<?> getObjectType() {
 		return DynamoDBMapper.class;
+	}
+
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.beanFactory = beanFactory;
 	}
 
 }


### PR DESCRIPTION
Changes in line with the JavaDoc on `org.springframework.beans.factory.FactoryBean<T>` use the `BeanFactory` instead of constructor autowired beans by implementing `BeanFactoryAware`.