### PR TITLE
Fix symlink to CONTRIBUTING.md

### DIFF
--- a/src/site/markdown/contributing.md
+++ b/src/site/markdown/contributing.md
@@ -1,1 +1,1 @@
-../../../CONTRIBUTING.md
+../../../.github/CONTRIBUTING.md


### PR DESCRIPTION
The `src/site/markdown/contributing.md` symlink was broken due to moving the target to the new `.github` directory. Fixed this.