### PR TITLE
Fix suggestion of issue #213

### DIFF
--- a/src/main/java/org/socialsignin/spring/data/dynamodb/query/AbstractSingleEntityQuery.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/query/AbstractSingleEntityQuery.java
@@ -17,6 +17,7 @@ package org.socialsignin.spring.data.dynamodb.query;
 
 import org.socialsignin.spring.data.dynamodb.core.DynamoDBOperations;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -28,6 +29,7 @@ public abstract class AbstractSingleEntityQuery<T> extends AbstractDynamicQuery<
 
 	@Override
 	public List<T> getResultList() {
-		return Arrays.asList(getSingleResult());
+		T result = getSingleResult();
+		return result != null ? Arrays.asList(result) : new ArrayList<>();
 	}
 }

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/query/AbstractSingleEntityQueryTest.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/query/AbstractSingleEntityQueryTest.java
@@ -15,7 +15,6 @@
  */
 package org.socialsignin.spring.data.dynamodb.query;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.socialsignin.spring.data.dynamodb.core.DynamoDBOperations;
@@ -29,27 +28,36 @@ public class AbstractSingleEntityQueryTest {
 
 	@Mock
 	private DynamoDBOperations dynamoDBOperations;
-	@Mock
-	private User entity;
+
+	private final User entity = new User();
 
 	private AbstractSingleEntityQuery<User> underTest;
 
-	@Before
-	public void setUp() {
+	@Test
+	public void testGetResultList() {
 		underTest = new AbstractSingleEntityQuery<User>(dynamoDBOperations, User.class) {
 			@Override
 			public User getSingleResult() {
 				return entity;
 			}
 		};
-	}
 
-	@Test
-	public void testGetResultList() {
 		List<User> actual = underTest.getResultList();
 
 		assertEquals(1, actual.size());
 		assertEquals(entity, actual.get(0));
+	}
+
+	@Test
+	public void testGetResultListEmpty() {
+		underTest = new AbstractSingleEntityQuery<User>(dynamoDBOperations, User.class) {
+			@Override
+			public User getSingleResult() { return null; }
+		};
+
+		List<User> actual = underTest.getResultList();
+
+		assertEquals(0, actual.size());
 	}
 
 }


### PR DESCRIPTION
Fix suggestion of issue #213

The idea is to include one more shield in the code to prevent the return of a list with null elements, which in my understanding is somewhat inconsistent. So with that addition, always that the return of `getSingleResult()` is null, a empty list will be returned.