### PR TITLE
Fix build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,11 @@
     </licenses>
 
     <properties>
-        <spring.version>5.2.9.RELEASE</spring.version>
-        <spring-data.version>2.6.0</spring-data.version>
+        <spring.version>5.3.15</spring.version>
+        <spring-data.version>2.4.15</spring-data.version>
 
-        <hibernate-validator.version>7.0.1.Final</hibernate-validator.version>
-        <aws-java-sdk.version>1.11.838</aws-java-sdk.version>
+        <hibernate-validator.version>6.2.2.Final</hibernate-validator.version>
+        <aws-java-sdk.version>1.12.150</aws-java-sdk.version>
         <junit.version>4.13.2</junit.version>
         <mockito.version>2.23.0</mockito.version>
         <cdi.version>2.0</cdi.version>
@@ -53,6 +53,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <spring-boot-starter-validation.version>2.6.3</spring-boot-starter-validation.version>
     </properties>
 
     <dependencyManagement>
@@ -147,6 +148,7 @@
 	    <dependency>
 		  <groupId>org.springframework.boot</groupId>
 		  <artifactId>spring-boot-starter-validation</artifactId>
+            <version>${spring-boot-starter-validation.version}</version>
 	    </dependency>
         <!-- SPRING DATA -->
         <dependency>
@@ -251,6 +253,11 @@
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.2</version>
+                    <configuration>
+                        <classpathDependencyExcludes>
+                            <classpathDependencyExcludes>ch.qos.logback:logback-classic</classpathDependencyExcludes>
+                        </classpathDependencyExcludes>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/repository/query/AbstractDynamoDBQueryTest.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/repository/query/AbstractDynamoDBQueryTest.java
@@ -17,10 +17,9 @@ package org.socialsignin.spring.data.dynamodb.repository.query;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -34,6 +33,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.socialsignin.spring.data.dynamodb.core.DynamoDBOperations;
@@ -45,12 +45,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.util.TypeInformation;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractDynamoDBQueryTest {
 
-	public static interface UserRepository extends CrudRepository<User, String> {
-		public Page<User> findByName(String name, Pageable pageable);
+	public interface UserRepository extends CrudRepository<User, String> {
+		Page<User> findByName(String name, Pageable pageable);
 	}
 	@Mock
 	private Query<User> query;
@@ -110,10 +111,15 @@ public class AbstractDynamoDBQueryTest {
 	@Mock
 	private RepositoryMetadata metadata;
 	@Mock
+	private TypeInformation typeInformation;
+	@Mock
 	private ProjectionFactory factory;
 
 	@Before
 	public void setUp() {
+		doReturn(Page.class).when(typeInformation).getType();
+		doReturn(typeInformation).when(metadata)
+			.getReturnType(ArgumentMatchers.argThat(argument -> "findByName".equals(argument.getName())));
 		doReturn(UserRepository.class).when(metadata).getRepositoryInterface();
 		doReturn(User.class).when(metadata).getReturnedDomainClass(any());
 	}

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/repository/support/SimpleDynamoDBCrudRepositoryTest.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/repository/support/SimpleDynamoDBCrudRepositoryTest.java
@@ -51,8 +51,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link DynamoDBSimpleIdRepository}.
- * 
+ * Unit tests for {@link SimpleDynamoDBCrudRepository}.
+ *
  * @author Michael Lavelle
  * @author Sebastian Just
  */
@@ -161,8 +161,8 @@ public class SimpleDynamoDBCrudRepositoryTest {
 
 	/**
 	 * /**
-	 * 
-	 * @see DATAJPA-177
+	 *
+	 * @see <a href="https://jira.spring.io/browse/DATAJPA-177">DATAJPA-177</a>
 	 */
 	@Test(expected = EmptyResultDataAccessException.class)
 	public void throwsExceptionIfEntityOnlyHashKeyToDeleteDoesNotExist() {
@@ -224,7 +224,7 @@ public class SimpleDynamoDBCrudRepositoryTest {
 	}
 
 	/**
-	 * @see DATAJPA-177
+	 * @see <a href="https://jira.spring.io/browse/DATAJPA-177">DATAJPA-177</a>
 	 */
 	@Test(expected = EmptyResultDataAccessException.class)
 	public void throwsExceptionIfEntityWithHashAndRangeKeyToDeleteDoesNotExist() {


### PR DESCRIPTION
This PR fixes the build, which has been broken since last November.

There were a few dependency conflicts, and the pom was missing a version for `spring-boot-starter-validation`. Here are a couple of points:

* I noticed that `spring-boot-starter-validation` was recently included. It imports `spring-boot-starter`, `tomcat-embedded`, and a lot of other things as transitive dependencies. I'm not sure how relevant this is, given this project could be used with a non-spring-boot project, and `hibernate-validator` is imported at top-level anyways.
* `hibernate-validator` 7.X.X uses the `jakarta.validation` packages, but the Spring framework (and Spring Boot) don't support them yet (planned in Q4, [source](https://spring.io/blog/2021/09/02/a-java-17-and-jakarta-ee-9-baseline-for-spring-framework-6)). I therefore downgraded `hibernate-validator` to the latest stable `6.X.X` version.
* I downgraded `spring-data-commons` because in `2.5` they added a new method (`deleteAllById(Iterable<ID> ids)`) to the `CrudRepository` interface, and that broke `SimpleDynamoDBCrudRepository`. The compilation error never showed up, because of the dependency was upgraded while the build was broken, and there is no simple way to implement it. I gave it a shot, and doing it cleanly would require adding a new method to the `DynamoDBOperations` interface to avoid having to call `findAllById()` in the implementation of `deleteAllById()`, and therefore doing a cost-prohibitive scan just to do a delete.

It looks like dependabot has been wreaking havoc in this repo over the last couple months. Maybe that's something that could be looked at in a later PR.

This is my first  contribution to this repo, and I'm hoping to submit more. I'll be happy to address any suggestions.